### PR TITLE
Updated Docker Aliases

### DIFF
--- a/bash/aliases
+++ b/bash/aliases
@@ -55,6 +55,7 @@ alias dcrake="docker compose run --rm rails rake"
 alias dcra="docker attach --detach-keys='ctrl-x' \$(docker compose ps -q rails)"
 alias dcember="docker compose run --rm ember yarn exec ember"
 alias dcets="docker compose run --rm -p 7357:7357 -d ember yarn start -e test -p 7357 && sleep 30 && open -a 'Google Chrome' http://localhost:7357/tests"
+alias dcpsql="docker compose run --rm db psql -U postgres -h host.docker.internal"
 
 function commitsnipe() {
   shadowprint "git commit --amend --no-edit --reset-author"

--- a/bash/aliases
+++ b/bash/aliases
@@ -50,10 +50,11 @@ alias gtrsh="git checkout --"
 alias gcopy='gl --pretty="%s" -1 | pbcopy'
 
 # Docker
-alias dcrails="docker compose run rails rails"
-alias dcrake="docker compose run rails rake"
-alias dcember="docker compose run ember yarn exec ember"
-alias dcets="docker compose run -p 7357:7357 -d ember yarn start -e test -p 7357 && sleep 30 && open -a 'Google Chrome' http://localhost:7357/tests"
+alias dcrails="docker compose run --rm rails rails"
+alias dcrake="docker compose run --rm rails rake"
+alias dcra="docker attach --detach-keys='ctrl-x' \$(docker compose ps -q rails)"
+alias dcember="docker compose run --rm ember yarn exec ember"
+alias dcets="docker compose run --rm -p 7357:7357 -d ember yarn start -e test -p 7357 && sleep 30 && open -a 'Google Chrome' http://localhost:7357/tests"
 
 function commitsnipe() {
   shadowprint "git commit --amend --no-edit --reset-author"

--- a/fish/aliases.fish
+++ b/fish/aliases.fish
@@ -175,6 +175,10 @@ function dcets
   open -a 'Google Chrome' http://localhost:7357/tests
 end
 
+function dcpqsl
+  docker compose run --rm db psql -U postgres -h host.docker.internal $argv
+end
+
 
 # Git Fetch and Merge; delete the branch upon success
 function gfmerge!

--- a/fish/aliases.fish
+++ b/fish/aliases.fish
@@ -154,19 +154,19 @@ end
 
 # Docker
 function dcrails
-  docker compose run rails rails $argv
+  docker compose run --rm rails rails $argv
 end
 
 function dcrake
-  docker compose run rails rake $argv
+  docker compose run --rm rails rake $argv
 end
 
 function dcember
-  docker compose run ember yarn exec ember $argv
+  docker compose run --rm ember yarn exec ember $argv
 end
 
 function dcets
-  docker compose run -p 7357:7357 -d ember yarn start -e test -p 7357
+  docker compose run --rm -p 7357:7357 -d ember yarn start -e test -p 7357
   sleep 30
   open -a 'Google Chrome' http://localhost:7357/tests
 end

--- a/fish/aliases.fish
+++ b/fish/aliases.fish
@@ -161,6 +161,10 @@ function dcrake
   docker compose run --rm rails rake $argv
 end
 
+function dcra
+  docker attach --detach-keys="ctrl-x" (docker compose ps -q rails)
+end
+
 function dcember
   docker compose run --rm ember yarn exec ember $argv
 end


### PR DESCRIPTION
### Summary
Added the `--rm` flag for the `run` invocations, which cleans up the one-off container after it's done running.

Also added a new alias: `dcpsql`, which invokes `psql` using the `db` service's configuration. Assumes configured with a `postgres` user.